### PR TITLE
Fixing squid: S1118 Utility classes should not have public constructor

### DIFF
--- a/ubersdk/src/main/java/com/neno0o/ubersdk/UberURLs.java
+++ b/ubersdk/src/main/java/com/neno0o/ubersdk/UberURLs.java
@@ -1,6 +1,8 @@
 package com.neno0o.ubersdk;
 
-public class UberURLs {
+public final class UberURLs {
+
+    private UberURLs(){}
 
     public static final String SCOPE_PROFILE = "profile";
     public static final String SCOPE_HISTORY_LITE = "history_lite";


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118
 Please let me know if you have any questions.
Fevzi Ozgul
