### PR TITLE
Fixing squid:S1700 A field should not duplicate the name of its containing class

### DIFF
--- a/ubersdk/src/main/java/com/neno0o/ubersdk/Endpoints/Models/Prices/Prices.java
+++ b/ubersdk/src/main/java/com/neno0o/ubersdk/Endpoints/Models/Prices/Prices.java
@@ -9,13 +9,13 @@ public class Prices {
 
     @Expose
     @SerializedName("prices")
-    private List<Price> prices;
+    private List<Price> pricesList;
 
     public List<Price> getPrices() {
-        return prices;
+        return pricesList;
     }
 
     public void setPrices(List<Price> prices) {
-        this.prices = prices;
+        this.pricesList = prices;
     }
 }

--- a/ubersdk/src/main/java/com/neno0o/ubersdk/Endpoints/Models/Products/Products.java
+++ b/ubersdk/src/main/java/com/neno0o/ubersdk/Endpoints/Models/Products/Products.java
@@ -9,13 +9,13 @@ public class Products {
 
     @Expose
     @SerializedName("products")
-    private List<Product> products;
+    private List<Product> productsList;
 
     public List<Product> getProducts() {
-        return products;
+        return productsList;
     }
 
     public void setProducts(List<Product> products) {
-        this.products = products;
+        this.productsList = products;
     }
 }

--- a/ubersdk/src/main/java/com/neno0o/ubersdk/Endpoints/Models/Times/Times.java
+++ b/ubersdk/src/main/java/com/neno0o/ubersdk/Endpoints/Models/Times/Times.java
@@ -9,13 +9,13 @@ public class Times {
 
     @Expose
     @SerializedName("times")
-    private List<Time> times;
+    private List<Time> timesList;
 
     public List<Time> getTimes() {
-        return times;
+        return timesList;
     }
 
     public void setTimes(List<Time> times) {
-        this.times = times;
+        this.timesList = times;
     }
 }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1700 - “A field should not duplicate the name of its class”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1700
 Please let me know if you have any questions.
Fevzi Ozgul
