### PR TITLE
Fixing squid: S1186 Methods should no be empty

### DIFF
--- a/app/src/main/java/com/neno0o/uber_android_sdk/MainActivity.java
+++ b/app/src/main/java/com/neno0o/uber_android_sdk/MainActivity.java
@@ -73,7 +73,7 @@ public class MainActivity extends AppCompatActivity {
 
                 @Override
                 public void failure(RetrofitError error) {
-
+                    throw new UnsupportedOperationException("This method is inot implemented yet!");
                 }
             });
         }

--- a/ubersdk/src/main/java/com/neno0o/ubersdk/Activites/Authentication.java
+++ b/ubersdk/src/main/java/com/neno0o/ubersdk/Activites/Authentication.java
@@ -93,7 +93,7 @@ public class Authentication extends AppCompatActivity {
 
                             @Override
                             public void failure(RetrofitError error) {
-
+                                throw new UnsupportedOperationException("This method is not implemented yet!");
                             }
                         }
                 );

--- a/ubersdk/src/main/java/com/neno0o/ubersdk/Auth/Models/AccessToken.java
+++ b/ubersdk/src/main/java/com/neno0o/ubersdk/Auth/Models/AccessToken.java
@@ -33,6 +33,7 @@ public class AccessToken {
     private String scope;
 
     public AccessToken() {
+        //TODO
     }
 
     public String getAccessTokenValue() {


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1186 - "Methods should not be empty”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1186
 Please let me know if you have any questions.
Fevzi Ozgul
