### PR TITLE
Fixing squid: S00116 Field names should comply with a naming convention

### DIFF
--- a/ubersdk/src/main/java/com/neno0o/ubersdk/Endpoints/Models/Products/Product.java
+++ b/ubersdk/src/main/java/com/neno0o/ubersdk/Endpoints/Models/Products/Product.java
@@ -49,7 +49,7 @@ public class Product {
      */
     @Expose
     @SerializedName("price_details")
-    private PriceDetails price_details;
+    private PriceDetails priceDetails;
 
 
     public String getProductId() {
@@ -93,11 +93,11 @@ public class Product {
     }
 
     public PriceDetails getPriceDetails() {
-        return price_details;
+        return priceDetails;
     }
 
     public void setPriceDetails(PriceDetails price_details) {
-        this.price_details = price_details;
+        this.priceDetails = price_details;
     }
 
     public class PriceDetails {
@@ -107,21 +107,21 @@ public class Product {
          */
         @Expose
         @SerializedName("service_fees")
-        private List<ServiceFees> service_fees;
+        private List<ServiceFees> serviceFees;
 
         /**
          * The unit of distance used to calculate the fare (either mile or km).
          */
         @Expose
         @SerializedName("distance_unit")
-        private String distance_unit;
+        private String distanceUnit;
 
         /**
          * The charge per minute (if applicable for the product type).
          */
         @Expose
         @SerializedName("cost_per_minute")
-        private double cost_per_minute;
+        private double costPerMinute;
 
         /**
          * The minimum price of a trip.
@@ -135,7 +135,7 @@ public class Product {
          */
         @Expose
         @SerializedName("cost_per_distance")
-        private double cost_per_distance;
+        private double costPerDistance;
 
         /**
          * The base price.
@@ -149,38 +149,38 @@ public class Product {
          */
         @Expose
         @SerializedName("cancellation_fee")
-        private double cancellation_fee;
+        private double cancellationFee;
 
         /**
          * ISO 4217 currency code.
          */
         @Expose
         @SerializedName("currency_code")
-        private String currency_code;
+        private String currencyCode;
 
 
         public List<ServiceFees> getServiceFees() {
-            return service_fees;
+            return serviceFees;
         }
 
         public void setServiceFees(List<ServiceFees> service_fees) {
-            this.service_fees = service_fees;
+            this.serviceFees = service_fees;
         }
 
         public String getDistanceUnit() {
-            return distance_unit;
+            return distanceUnit;
         }
 
         public void setDistanceUnit(String distance_unit) {
-            this.distance_unit = distance_unit;
+            this.distanceUnit = distance_unit;
         }
 
         public double getCostPerMinute() {
-            return cost_per_minute;
+            return costPerMinute;
         }
 
         public void setCostPerMinute(double cost_per_minute) {
-            this.cost_per_minute = cost_per_minute;
+            this.costPerMinute = cost_per_minute;
         }
 
         public double getMinimum() {
@@ -192,11 +192,11 @@ public class Product {
         }
 
         public double getCostPerDistance() {
-            return cost_per_distance;
+            return costPerDistance;
         }
 
         public void setCostPerDistance(double cost_per_distance) {
-            this.cost_per_distance = cost_per_distance;
+            this.costPerDistance = cost_per_distance;
         }
 
         public double getBase() {
@@ -208,19 +208,19 @@ public class Product {
         }
 
         public double getCancellationFee() {
-            return cancellation_fee;
+            return cancellationFee;
         }
 
         public void setCancellationFee(double cancellation_fee) {
-            this.cancellation_fee = cancellation_fee;
+            this.cancellationFee = cancellation_fee;
         }
 
         public String getCurrencyCode() {
-            return currency_code;
+            return currencyCode;
         }
 
         public void setCurrencyCode(String currency_code) {
-            this.currency_code = currency_code;
+            this.currencyCode = currency_code;
         }
 
         public class ServiceFees {

--- a/ubersdk/src/main/java/com/neno0o/ubersdk/Endpoints/Models/Requests/EstimateRequest/EstimatePrice.java
+++ b/ubersdk/src/main/java/com/neno0o/ubersdk/Endpoints/Models/Requests/EstimateRequest/EstimatePrice.java
@@ -10,21 +10,21 @@ public class EstimatePrice {
      */
     @Expose
     @SerializedName("surge_confirmation_href")
-    private String surge_confirmation_href;
+    private String surgeConfirmationHref;
 
     /**
      * Upper bound of the estimated price.
      */
     @Expose
     @SerializedName("high_estimate")
-    private int high_estimate;
+    private int highEstimate;
 
     /**
      * The unique identifier of the surge session for a user. null if no surge is currently in effect.
      */
     @Expose
     @SerializedName("surge_confirmation_id")
-    private String surge_confirmation_id;
+    private String surgeConfirmationId;
 
     /**
      * The minimum fare of a trip. Should only be displayed or used if no end location is provided.
@@ -38,14 +38,14 @@ public class EstimatePrice {
      */
     @Expose
     @SerializedName("low_estimate")
-    private int low_estimate;
+    private int lowEstimate;
 
     /**
      * Expected surge multiplier. Surge is active if surge_multiplier is greater than 1. Fare estimates below factor in the surge multiplier.
      */
     @Expose
     @SerializedName("surge_multiplier")
-    private double surge_multiplier;
+    private double surgeMultiplier;
 
     /**
      * Formatted string of estimate in local currency of the start location.
@@ -60,31 +60,31 @@ public class EstimatePrice {
      */
     @Expose
     @SerializedName("currency_code")
-    private String currency_code;
+    private String currencyCode;
 
 
     public String getSurge_confirmation_href() {
-        return surge_confirmation_href;
+        return surgeConfirmationHref;
     }
 
     public void setSurge_confirmation_href(String surge_confirmation_href) {
-        this.surge_confirmation_href = surge_confirmation_href;
+        this.surgeConfirmationHref = surge_confirmation_href;
     }
 
     public int getHigh_estimate() {
-        return high_estimate;
+        return highEstimate;
     }
 
     public void setHigh_estimate(int high_estimate) {
-        this.high_estimate = high_estimate;
+        this.highEstimate = high_estimate;
     }
 
     public String getSurge_confirmation_id() {
-        return surge_confirmation_id;
+        return surgeConfirmationId;
     }
 
     public void setSurge_confirmation_id(String surge_confirmation_id) {
-        this.surge_confirmation_id = surge_confirmation_id;
+        this.surgeConfirmationId = surge_confirmation_id;
     }
 
     public int getMinimum() {
@@ -96,19 +96,19 @@ public class EstimatePrice {
     }
 
     public int getLow_estimate() {
-        return low_estimate;
+        return lowEstimate;
     }
 
     public void setLow_estimate(int low_estimate) {
-        this.low_estimate = low_estimate;
+        this.lowEstimate = low_estimate;
     }
 
     public double getSurge_multiplier() {
-        return surge_multiplier;
+        return surgeMultiplier;
     }
 
     public void setSurge_multiplier(double surge_multiplier) {
-        this.surge_multiplier = surge_multiplier;
+        this.surgeMultiplier = surge_multiplier;
     }
 
     public String getDisplay() {
@@ -120,10 +120,10 @@ public class EstimatePrice {
     }
 
     public String getCurrency_code() {
-        return currency_code;
+        return currencyCode;
     }
 
     public void setCurrency_code(String currency_code) {
-        this.currency_code = currency_code;
+        this.currencyCode = currency_code;
     }
 }

--- a/ubersdk/src/main/java/com/neno0o/ubersdk/Endpoints/Models/Requests/EstimateRequest/Trip.java
+++ b/ubersdk/src/main/java/com/neno0o/ubersdk/Endpoints/Models/Requests/EstimateRequest/Trip.java
@@ -10,43 +10,43 @@ public class Trip {
      */
     @Expose
     @SerializedName("distance_unit")
-    private String distance_unit;
+    private String distanceUnit;
 
     /**
      * Expected activity duration (in minutes).
      */
     @Expose
     @SerializedName("duration_estimate")
-    private int duration_estimate;
+    private int durationEstimate;
 
     /**
      * Expected activity distance.
      */
     @Expose
     @SerializedName("distance_estimate")
-    private double distance_estimate;
+    private double distanceEstimate;
 
     public String getDistance_unit() {
-        return distance_unit;
+        return distanceUnit;
     }
 
     public void setDistance_unit(String distance_unit) {
-        this.distance_unit = distance_unit;
+        this.distanceUnit = distance_unit;
     }
 
     public int getDuration_estimate() {
-        return duration_estimate;
+        return durationEstimate;
     }
 
     public void setDuration_estimate(int duration_estimate) {
-        this.duration_estimate = duration_estimate;
+        this.durationEstimate = duration_estimate;
     }
 
     public double getDistance_estimate() {
-        return distance_estimate;
+        return distanceEstimate;
     }
 
     public void setDistance_estimate(double distance_estimate) {
-        this.distance_estimate = distance_estimate;
+        this.distanceEstimate = distance_estimate;
     }
 }

--- a/ubersdk/src/main/java/com/neno0o/ubersdk/Endpoints/Models/Requests/EstimateRequest/UberEstimateRequest.java
+++ b/ubersdk/src/main/java/com/neno0o/ubersdk/Endpoints/Models/Requests/EstimateRequest/UberEstimateRequest.java
@@ -10,7 +10,7 @@ public class UberEstimateRequest {
      */
     @Expose
     @SerializedName("pickup_estimate")
-    private int pickup_estimate;
+    private int pickupEstimate;
 
     /**
      * Details of the estimated fare. If end location is omitted, only the minimum is returned.
@@ -28,11 +28,11 @@ public class UberEstimateRequest {
 
 
     public int getPickup_estimate() {
-        return pickup_estimate;
+        return pickupEstimate;
     }
 
     public void setPickup_estimate(int pickup_estimate) {
-        this.pickup_estimate = pickup_estimate;
+        this.pickupEstimate = pickup_estimate;
     }
 
     public EstimatePrice getPrice() {

--- a/ubersdk/src/main/java/com/neno0o/ubersdk/Endpoints/Models/Requests/ReceiptRequest/UberReceiptRequest.java
+++ b/ubersdk/src/main/java/com/neno0o/ubersdk/Endpoints/Models/Requests/ReceiptRequest/UberReceiptRequest.java
@@ -12,14 +12,14 @@ public class UberReceiptRequest {
      */
     @Expose
     @SerializedName("request_id")
-    private String request_id;
+    private String requestId;
 
     /**
      * The summation of the charges.
      */
     @Expose
     @SerializedName("normal_fare")
-    private double normal_fare;
+    private double normalFare;
 
     /**
      * The summation of the normal_fare and surge_charge.
@@ -33,21 +33,21 @@ public class UberReceiptRequest {
      */
     @Expose
     @SerializedName("total_charged")
-    private double total_charged;
+    private double totalCharged;
 
     /**
      * The total amount still owed after attempting to charge the user. May be null if amount was paid in full.
      */
     @Expose
     @SerializedName("total_owed")
-    private double total_owed;
+    private double totalOwed;
 
     /**
      * ISO 4217
      */
     @Expose
     @SerializedName("currency_code")
-    private String currency_code;
+    private String currencyCode;
 
     /**
      * Time duration of the trip in ISO 8061 HH:MM:SS format.
@@ -68,7 +68,7 @@ public class UberReceiptRequest {
      */
     @Expose
     @SerializedName("distance_label")
-    private String distance_label;
+    private String distanceLabel;
 
     /**
      * Describes the charges made against the rider.
@@ -82,7 +82,7 @@ public class UberReceiptRequest {
      */
     @Expose
     @SerializedName("surge_charge")
-    private SurgeCharge surge_charge;
+    private SurgeCharge surgeCharge;
 
     /**
      * Adjustments made to the charges such as promotions, and fees.
@@ -93,19 +93,19 @@ public class UberReceiptRequest {
 
 
     public String getRequest_id() {
-        return request_id;
+        return requestId;
     }
 
     public void setRequest_id(String request_id) {
-        this.request_id = request_id;
+        this.requestId = request_id;
     }
 
     public double getNormal_fare() {
-        return normal_fare;
+        return normalFare;
     }
 
     public void setNormal_fare(double normal_fare) {
-        this.normal_fare = normal_fare;
+        this.normalFare = normal_fare;
     }
 
     public double getSubtotal() {
@@ -117,27 +117,27 @@ public class UberReceiptRequest {
     }
 
     public double getTotal_charged() {
-        return total_charged;
+        return totalCharged;
     }
 
     public void setTotal_charged(double total_charged) {
-        this.total_charged = total_charged;
+        this.totalCharged = total_charged;
     }
 
     public double getTotal_owed() {
-        return total_owed;
+        return totalOwed;
     }
 
     public void setTotal_owed(double total_owed) {
-        this.total_owed = total_owed;
+        this.totalOwed = total_owed;
     }
 
     public String getCurrency_code() {
-        return currency_code;
+        return currencyCode;
     }
 
     public void setCurrency_code(String currency_code) {
-        this.currency_code = currency_code;
+        this.currencyCode = currency_code;
     }
 
     public String getDuration() {
@@ -157,11 +157,11 @@ public class UberReceiptRequest {
     }
 
     public String getDistance_label() {
-        return distance_label;
+        return distanceLabel;
     }
 
     public void setDistance_label(String distance_label) {
-        this.distance_label = distance_label;
+        this.distanceLabel = distance_label;
     }
 
     public List<Charges> getCharges() {
@@ -173,11 +173,11 @@ public class UberReceiptRequest {
     }
 
     public SurgeCharge getSurge_charge() {
-        return surge_charge;
+        return surgeCharge;
     }
 
     public void setSurge_charge(SurgeCharge surge_charge) {
-        this.surge_charge = surge_charge;
+        this.surgeCharge = surge_charge;
     }
 
     public List<ChargeAdjustments> getCharge_adjustments() {

--- a/ubersdk/src/main/java/com/neno0o/ubersdk/Endpoints/Models/Times/Time.java
+++ b/ubersdk/src/main/java/com/neno0o/ubersdk/Endpoints/Models/Times/Time.java
@@ -29,7 +29,7 @@ public class Time {
 
     @Expose
     @SerializedName("localized_display_name")
-    private String localized_display_name;
+    private String localizedDisplayName;
 
     public String getProductId() {
         return productId;
@@ -56,10 +56,10 @@ public class Time {
     }
 
     public String getLocalized_display_name() {
-        return localized_display_name;
+        return localizedDisplayName;
     }
 
     public void setLocalized_display_name(String localized_display_name) {
-        this.localized_display_name = localized_display_name;
+        this.localizedDisplayName = localized_display_name;
     }
 }

--- a/ubersdk/src/main/java/com/neno0o/ubersdk/Endpoints/Models/UserActivity/UserHistory.java
+++ b/ubersdk/src/main/java/com/neno0o/ubersdk/Endpoints/Models/UserActivity/UserHistory.java
@@ -12,7 +12,7 @@ public class UserHistory {
      */
     @Expose
     @SerializedName("request_id")
-    private String request_id;
+    private String requestId;
 
     /**
      * Unix timestamp of activity request time.
@@ -62,15 +62,15 @@ public class UserHistory {
      */
     @Expose
     @SerializedName("start_city")
-    private StartCity start_city;
+    private StartCity startCity;
 
 
     public String getRequest_id() {
-        return request_id;
+        return requestId;
     }
 
     public void setRequest_id(String request_id) {
-        this.request_id = request_id;
+        this.requestId = request_id;
     }
 
     public Date getRequestTime() {
@@ -122,11 +122,11 @@ public class UserHistory {
     }
 
     public StartCity getStart_city() {
-        return start_city;
+        return startCity;
     }
 
     public void setStart_city(StartCity start_city) {
-        this.start_city = start_city;
+        this.startCity = start_city;
     }
 
     public class StartCity {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S00116 - “Field names should comply with a naming convention”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S00116
 Please let me know if you have any questions.
Fevzi Ozgul
